### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/language/bing_spell_check/bing_spell_check.dart
+++ b/lib/language/bing_spell_check/bing_spell_check.dart
@@ -31,7 +31,7 @@ class BingSpellCheckService {
     request.write("text=" + text);
     HttpClientResponse response = await request.close();
     if (response.statusCode == 200) {
-      String reply = await response.transform(utf8.decoder).join();
+      String reply = await utf8.decoder.bind(response).join();
       httpClient.close();
       return reply;
     } else {

--- a/lib/language/translate_text/translate_text_service.dart
+++ b/lib/language/translate_text/translate_text_service.dart
@@ -40,7 +40,7 @@ class TranslateTextService {
     request.add(utf8.encode(json.encode(jsonMap)));
     HttpClientResponse response = await request.close();
     if (response.statusCode == 200) {
-      String reply = await response.transform(utf8.decoder).join();
+      String reply = await utf8.decoder.bind(response).join();
       httpClient.close();
       return reply;
     } else {


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
